### PR TITLE
Fix time formatter for minutes in Line chart

### DIFF
--- a/src/components/LineChart/hooks/useAxisProps.ts
+++ b/src/components/LineChart/hooks/useAxisProps.ts
@@ -32,9 +32,7 @@ export const useAxisProps = ({
     const axisTopBottomConfig = {
       format:
         xScaleType === 'time'
-          ? axisBottomFormat === 'minutes'
-            ? '%M:%S'
-            : axisBottomFormat === 'hours'
+          ? axisBottomFormat === 'minutes' || axisBottomFormat === 'hours'
             ? '%H:%M'
             : '%d %b'
           : xFormatter,


### PR DESCRIPTION
# Fix time formatter for minutes in Line chart

Line chart component rendering minutes got formatting `mm:ss`. This looks a little confusing for the user and making of context about the hour being rendered.  The change creates output like `HH:mm`. This looks better and we don't care about seconds rendering minutes chart.

<img width="1119" alt="Screenshot 2024-05-02 at 18 13 29" src="https://github.com/Reya-Labs/brokoli-ui/assets/8999280/fbf47b9a-def4-4b11-996d-91f079fb991e">
