### PR TITLE
fix: chart margin calculator

### DIFF
--- a/src/utils/get-text-width/get-span-text-width.ts
+++ b/src/utils/get-text-width/get-span-text-width.ts
@@ -17,8 +17,10 @@ export function getSpanTextWidth(str: string, style: object): number {
       textEl.style.left = '-100%';
       // Append the span to the body
       document.body.appendChild(textEl);
+    } else {
+      Object.assign(textEl.style, style);
+      textEl.textContent = str;
     }
-    Object.assign(textEl.style, style);
     return textEl.offsetWidth;
   } catch (e) {
     return 0;


### PR DESCRIPTION
# Fix chart margin calculator

An issue with a margin of y axis values offset calculation.

<img width="857" alt="332196163-077e8121-c8e3-4478-a9ea-ae647afec13e" src="https://github.com/Reya-Labs/brokoli-ui/assets/8999280/2c814304-9493-4d64-bbb0-d99dd6bb7edf">
