### PR TITLE
fix: visx chart y axis ticks width

### DIFF
--- a/src/components/VisxChart/VisxTimelineChart/index.tsx
+++ b/src/components/VisxChart/VisxTimelineChart/index.tsx
@@ -176,7 +176,8 @@ const _VisxTimelineChart = ({
       -Infinity,
     ] as const);
 
-    const yTickValues = _range(yMin, yMax, axisNumTicks);
+    const step = Math.abs((yMin - yMax) / (axisNumTicks - 1));
+    const yTickValues = _range(yMin, yMax, step);
     const widths =
       marginComputationalValue === 'auto'
         ? yTickValues.map((d) =>


### PR DESCRIPTION
# visx chart y-axis ticks width

lodash `range` function third input is a step. It was falsely assumed that it was a count of items returned. Because of this only the first number was taken into account while calculating the width of the y-axis ticks

